### PR TITLE
Fail visibly + /usr/share

### DIFF
--- a/vimmified/Makefile
+++ b/vimmified/Makefile
@@ -1,7 +1,16 @@
 INPUT_FILES = 1_editor_fundamentals.txt 2_line_addresses.txt 2_line_addresses_solutions.txt 3_global_command.txt 3_global_command_solutions.txt 4_substitute_command.txt
 HTML_DIR = html
 HTML_FILES = $(addprefix html/,$(INPUT_FILES:txt=html))
-ICONS_DIR = /etc/asciidoc/images/icons/
+ETC_ASCIIDOC_ICONS = /etc/asciidoc/images/icons/
+SHARE_ASCIIDOC_ICONS = /usr/share/asciidoc/images/icons/
+ifneq "$(wildcard $(ETC_ASCIIDOC_ICONS) ])" ''
+    ICONS_DIR = $(ETC_ASCIIDOC_ICONS)
+else
+    ifeq "$(wildcard $(SHARE_ASCIIDOC_ICONS) ])" ''
+    	$(error Missing $(ETC_ASCIIDOC_ICONS) and $(SHARE_ASCIIDOC_ICONS))
+    endif
+    ICONS_DIR = $(SHARE_ASCIIDOC_ICONS)
+endif
 
 .PHONY: all html5 clean
 
@@ -9,13 +18,12 @@ all: html5
 
 html5: $(HTML_FILES)
 
-$(HTML_FILES): | $(HTML_DIR)
+$(HTML_FILES): demand_pygments | $(HTML_DIR)
 
 $(HTML_DIR):
 	mkdir $(HTML_DIR)
 
 html/%.html: %.txt
-	echo $(ICONS_DIR)
 	asciidoc -v -b html5 \
 		-a toc2 \
 		-a toclevels=3 \
@@ -27,7 +35,10 @@ html/%.html: %.txt
 		-o $@ \
 		$<
 
+demand_pygments:
+	type pygmentize >/dev/null
+
 clean:
-	rm -fr html
+	rm -fr $(HTML_DIR)
 
 # vim: set noet tw=80:


### PR DESCRIPTION
Previously, this would hum along happily doing nothing if you were missing
pygmentize, and it would also not complain if the icons dir was missing.

Now it refuses to proceed if those are true.

Additionally, allow /usr/share/asciidoc instead of /etc/asciidoc. I don't think
the latter is even correct under the FHS.
