### PR TITLE
[Exercise 3.3] Solution using Arabic numerals

### DIFF
--- a/vimmified/3_global_command_solutions.txt
+++ b/vimmified/3_global_command_solutions.txt
@@ -116,3 +116,33 @@ line, next run the substitution that adds a capital I to all remaining
 macro lines, then return to the line and run the substitutions that
 produce a true Roman numeral. Bonus points for actually trying this.
 
+
+It is possible to number the paragraphs with Arabic numerals using only
+one `:global` command:
+
+[source,vim]
+----
+  global /^\.pp$/ copy . | - delete _ | ?^\.pp? copy - | substitute /\d*$/\=(submatch(0) + 1)/ | + delete _
+----
+
+For each line containing the `^\.pp$` pattern it does:
+
+. `copy .` — duplicate the line; this and the corresponding last
+`+ delete _` command are necessary to make sure the script works even
+in a file with only one `.pp` line;
+
+. `- delete _ | ?^\.pp? copy -` — replaces the original `.pp` line
+with the previous `.pp` line which may already contain a paragraph
+number; for the first marked line the `.pp` will be pasted back (in
+case of a file with only one `.pp` line, our duplicate from the first
+step will come in handy because the backwards search will wrap around
+the file); for the second marked line the `.pp1` will be pasted; etc.
+
+. `substitute /\d*$/\=(submatch(0) + 1)/` — for the newly pasted
+line, it will increment the last number found on the line; the search
+pattern is `\d*` to match `0+` digits so it will even match the original
+`.pp` line without a number, and `$` just to make sure it's at the end
+of the line; the replacement pattern uses an expression after `\=`, the
+`submatch(0)` function will return the found number or `0`, which will
+be incremented.
+


### PR DESCRIPTION
the explanation is in the file. the solution does use some not yet explained tricks (i don't know yet if they are in the chapter 4).

* it was an interesting puzzle, i tried to solve it for a few days. my first solution was:
    ```vim
    global /^\.pp$/ s/$/^M^M#0/ | 1,- s/\v#@<=\d+$/\=(submatch(0) + 1)/
    ```
  which worked, but numbered the paragraphs in the decreasing order; i couldn't figure out how to reverse it (reverse the whole file before and after the command, or make `:g` work backwards) in one `:g` command;

* i was wondering why the description simplified the condition of up to 35 paragraphs in a file and came up with a theory that it had something to do with `:registers`: `35 = 26 ` letters ` + 10 ` digits ` - 1`, but no…

* the description implies the hierarchy: `file > sections > paragraphs`, however the example only shows the `.pp` as the paragraph separator and there are really no sections in the problem or solution. so the description can be simplified to avoid unnecessary concepts, maybe `file = section`.